### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,9 +1,9 @@
 Authors
 -------
 
-Flask-Notifications is developed for use in `Invenio <http://invenio-software.org>`_
+Flask-Notifications is developed for use in `Invenio <http://inveniosoftware.org>`_
 digital library software.
 
-Contact Invenio at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact Invenio at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 * Jorge Vicente Cantero <jorgevc@fastmail.es>

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     url='https://github.com/inveniosoftware/flask-notifications',
     license='BSD',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description='Flask-Notifications is a Flask extension that adds support '
                 'for real-time notifications.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
